### PR TITLE
Create PSR-16 cache

### DIFF
--- a/app/Services/CacheService.php
+++ b/app/Services/CacheService.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Provide caching functions.
+ */
+class FreshRSS_Cache_Service implements CacheInterface {
+
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key     The unique key of this item in the cache.
+	 * @param mixed  $default Default value to return if the key does not exist.
+	 *
+	 * @return mixed The value of the item from the cache, or $default in case of cache miss.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function get(string $key, mixed $default = null): mixed {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+	 *
+	 * @param string                 $key   The key of the item to store.
+	 * @param mixed                  $value The value of the item to store, must be serializable.
+	 * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+	 *                                      the driver supports TTL then the library may set a default value
+	 *                                      for it or let the driver take care of that.
+	 *
+	 * @return bool True on success and false on failure.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Delete an item from the cache by its unique key.
+	 *
+	 * @param string $key The unique cache key of the item to delete.
+	 *
+	 * @return bool True if the item was successfully removed. False if there was an error.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function delete(string $key): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Wipes clean the entire cache's keys.
+	 *
+	 * @return bool True on success and false on failure.
+	 */
+	public function clear(): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Obtains multiple cache items by their unique keys.
+	 *
+	 * @param iterable<string> $keys    A list of keys that can be obtained in a single operation.
+	 * @param mixed            $default Default value to return for keys that do not exist.
+	 *
+	 * @return iterable<string, mixed> A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if $keys is neither an array nor a Traversable,
+	 *   or if any of the $keys are not a legal value.
+	 */
+	public function getMultiple(iterable $keys, mixed $default = null): iterable {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Persists a set of key => value pairs in the cache, with an optional TTL.
+	 *
+	 * @param iterable               $values A list of key => value pairs for a multiple-set operation.
+	 * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+	 *                                       the driver supports TTL then the library may set a default value
+	 *                                       for it or let the driver take care of that.
+	 *
+	 * @return bool True on success and false on failure.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if $values is neither an array nor a Traversable,
+	 *   or if any of the $values are not a legal value.
+	 */
+	public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Deletes multiple cache items in a single operation.
+	 *
+	 * @param iterable<string> $keys A list of string-based keys to be deleted.
+	 *
+	 * @return bool True if the items were successfully removed. False if there was an error.
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if $keys is neither an array nor a Traversable,
+	 *   or if any of the $keys are not a legal value.
+	 */
+	public function deleteMultiple(iterable $keys): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+
+	/**
+	 * Determines whether an item is present in the cache.
+	 *
+	 * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+	 * and not to be used within your live applications operations for get/set, as this method
+	 * is subject to a race condition where your has() will return true and immediately after,
+	 * another script can remove it making the state of your app out of date.
+	 *
+	 * @param string $key The cache item key.
+	 *
+	 * @return bool
+	 *
+	 * @throws \Psr\SimpleCache\InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function has(string $key): bool {
+		throw new \Exception(__METHOD__ . 'is not yet implemented');
+	}
+}

--- a/app/Services/CacheService.php
+++ b/app/Services/CacheService.php
@@ -75,7 +75,13 @@ class FreshRSS_Cache_Service implements CacheInterface {
 	 *   MUST be thrown if the $key string is not a legal value.
 	 */
 	public function delete(string $key): bool {
-		throw new \Exception(__METHOD__ . 'is not yet implemented');
+		$filepath = $this->createFilepath($key);
+
+		if (file_exists($filepath) && is_readable($filepath)) {
+			return unlink(file_get_contents($filepath));
+		}
+
+		return false;
 	}
 
 	/**

--- a/app/Services/CacheService.php
+++ b/app/Services/CacheService.php
@@ -35,7 +35,7 @@ class FreshRSS_Cache_Service implements CacheInterface {
 			return unserialize(file_get_contents($filepath));
 		}
 
-		return false;
+		return $default;
 	}
 
 	/**
@@ -53,7 +53,15 @@ class FreshRSS_Cache_Service implements CacheInterface {
 	 *   MUST be thrown if the $key string is not a legal value.
 	 */
 	public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool {
-		throw new \Exception(__METHOD__ . 'is not yet implemented');
+		$filepath = $this->createFilepath($key);
+
+		if (file_exists($filepath) && is_writable($filepath) || file_exists($this->location) && is_writable($this->location)) {
+			$data = serialize($value);
+
+			return (bool) file_put_contents($filepath, $data);
+		}
+
+		return false;
 	}
 
 	/**

--- a/app/Services/CacheService.php
+++ b/app/Services/CacheService.php
@@ -144,7 +144,17 @@ class FreshRSS_Cache_Service implements CacheInterface {
 	 * @return bool True on success and false on failure.
 	 */
 	public function clear(): bool {
-		throw new \Exception(__METHOD__ . 'is not yet implemented');
+		// N.B.: GLOB_BRACE is not available on all platforms
+		$files = array_merge(
+			glob($this->location . '/*.' . $this->extension, GLOB_NOSORT) ?: [],
+			glob($this->location . '/*.' . $this->extension . '.' . $this->metaExtension, GLOB_NOSORT) ?: [],
+		);
+
+		foreach ($files as $file) {
+			unlink($file);
+		}
+
+		return true;
 	}
 
 	/**

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -18,6 +18,7 @@
         "marienfressinaud/lib_opml": "0.5.1",
         "phpgt/cssxpath": "dev-master#d99d35f7194bac19fb3f8726b70c1bc83de3e931",
         "phpmailer/phpmailer": "6.9.1",
+        "psr/simple-cache": "^3.0",
         "simplepie/simplepie": "dev-cache-hash#82ae104433c0974fbcec1746e28fc017f146d18b"
     },
     "config": {

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -425,7 +425,6 @@ function cleanCache(int $hours = 720): void {
 	$files = array_merge(
 		glob(CACHE_PATH . '/*.html', GLOB_NOSORT) ?: [],
 		glob(CACHE_PATH . '/*.json', GLOB_NOSORT) ?: [],
-		glob(CACHE_PATH . '/*.spc', GLOB_NOSORT) ?: [],
 		glob(CACHE_PATH . '/*.xml', GLOB_NOSORT) ?: []);
 	foreach ($files as $file) {
 		if (substr($file, -10) === 'index.html') {
@@ -436,6 +435,8 @@ function cleanCache(int $hours = 720): void {
 			unlink($file);
 		}
 	}
+
+	(new FreshRSS_Cache_Service(CACHE_PATH))->clearExpired();
 }
 
 /**

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -321,7 +321,7 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 	}
 	$simplePie->set_useragent(FRESHRSS_USERAGENT);
 	$simplePie->set_cache_name_function('sha1');
-	$simplePie->set_cache_location(CACHE_PATH);
+	$simplePie->set_cache(new FreshRSS_Cache_Service(CACHE_PATH));
 	$simplePie->set_cache_duration($limits['cache_duration']);
 	$simplePie->enable_order_by_date(false);
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -88,6 +88,11 @@ function classAutoloader(string $class): void {
 		$base_dir = LIB_PATH . '/simplepie/simplepie/src/';
 		$relative_class_name = substr($class, strlen($prefix));
 		include $base_dir . str_replace('\\', '/', $relative_class_name) . '.php';
+	} elseif (str_starts_with($class, 'Psr\\SimpleCache\\')) {
+		$prefix = 'Psr\\SimpleCache\\';
+		$base_dir = LIB_PATH . '/psr/simple-cache/src/';
+		$relative_class_name = substr($class, strlen($prefix));
+		include $base_dir . str_replace('\\', '/', $relative_class_name) . '.php';
 	} elseif (str_starts_with($class, 'Gt\\CssXPath\\')) {
 		$prefix = 'Gt\\CssXPath\\';
 		$base_dir = LIB_PATH . '/phpgt/cssxpath/src/';

--- a/lib/psr/simple-cache/.editorconfig
+++ b/lib/psr/simple-cache/.editorconfig
@@ -1,0 +1,12 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/lib/psr/simple-cache/LICENSE.md
+++ b/lib/psr/simple-cache/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2016 PHP Framework Interoperability Group
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/lib/psr/simple-cache/README.md
+++ b/lib/psr/simple-cache/README.md
@@ -1,0 +1,8 @@
+PHP FIG Simple Cache PSR
+========================
+
+This repository holds all interfaces related to PSR-16.
+
+Note that this is not a cache implementation of its own. It is merely an interface that describes a cache implementation. See [the specification](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-16-simple-cache.md) for more details.
+
+You can find implementations of the specification by looking for packages providing the [psr/simple-cache-implementation](https://packagist.org/providers/psr/simple-cache-implementation) virtual package.

--- a/lib/psr/simple-cache/composer.json
+++ b/lib/psr/simple-cache/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "psr/simple-cache",
+    "description": "Common interfaces for simple caching",
+    "keywords": ["psr", "psr-16", "cache", "simple-cache", "caching"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "PHP-FIG",
+            "homepage": "https://www.php-fig.org/"
+        }
+    ],
+    "require": {
+        "php": ">=8.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Psr\\SimpleCache\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
+    }
+}

--- a/lib/psr/simple-cache/src/CacheException.php
+++ b/lib/psr/simple-cache/src/CacheException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+/**
+ * Interface used for all types of exceptions thrown by the implementing library.
+ */
+interface CacheException extends \Throwable
+{
+}

--- a/lib/psr/simple-cache/src/CacheInterface.php
+++ b/lib/psr/simple-cache/src/CacheInterface.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+interface CacheInterface
+{
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key     The unique key of this item in the cache.
+     * @param mixed  $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string                 $key   The key of the item to store.
+     * @param mixed                  $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool;
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete(string $key): bool;
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear(): bool;
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable<string> $keys    A list of keys that can be obtained in a single operation.
+     * @param mixed            $default Default value to return for keys that do not exist.
+     *
+     * @return iterable<string, mixed> A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable;
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable               $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     *                                       the driver supports TTL then the library may set a default value
+     *                                       for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool;
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable<string> $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple(iterable $keys): bool;
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has(string $key): bool;
+}

--- a/lib/psr/simple-cache/src/InvalidArgumentException.php
+++ b/lib/psr/simple-cache/src/InvalidArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Psr\SimpleCache;
+
+/**
+ * Exception interface for invalid cache arguments.
+ *
+ * When an invalid argument is passed it must throw an exception which implements
+ * this interface
+ */
+interface InvalidArgumentException extends CacheException
+{
+}

--- a/tests/app/Services/CacheServiceTest.php
+++ b/tests/app/Services/CacheServiceTest.php
@@ -6,4 +6,8 @@ final class CacheServiceTest extends PHPUnit\Framework\TestCase
 	public function testCacheServiceExists(): void {
 		self::assertTrue(class_exists(FreshRSS_Cache_Service::class));
 	}
+
+	public function testCacheServiceCanBeCreated(): void {
+		self::assertInstanceOf(FreshRSS_Cache_Service::class, new FreshRSS_Cache_Service(''));
+	}
 }

--- a/tests/app/Services/CacheServiceTest.php
+++ b/tests/app/Services/CacheServiceTest.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+final class CacheServiceTest extends PHPUnit\Framework\TestCase
+{
+	public function testCacheServiceExists(): void {
+		self::assertTrue(class_exists(FreshRSS_Cache_Service::class));
+	}
+}


### PR DESCRIPTION
Refs https://github.com/FreshRSS/simplepie/pull/11

This PR is a poc for a [PSR-16](https://www.php-fig.org/psr/psr-16/) cache implementation using in SimplePie 1.8.0, based on PR https://github.com/FreshRSS/FreshRSS/pull/4374

Changes proposed in this pull request:

- Allows better cache optimizations with SimplePie 1.8.0
- Makes most changes in the cache class of the SimplePie fork not necessary.

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
